### PR TITLE
Added Accessor Functions to Zoom

### DIFF
--- a/gwt-d3-api/src/main/java/com/github/gwtd3/api/behaviour/Zoom.java
+++ b/gwt-d3-api/src/main/java/com/github/gwtd3/api/behaviour/Zoom.java
@@ -25,7 +25,9 @@
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * 
  */
+
 package com.github.gwtd3.api.behaviour;
 
 import com.github.gwtd3.api.D3;
@@ -47,7 +49,6 @@ import com.google.gwt.core.client.JavaScriptObject;
  * 	&#064;code
  * 	Zoom zoom = D3.behavior.zoom().on(ZoomEventType.Zoom, new MyZoomListener());
  * 	mySelection.call(zoom);
- * 
  * }
  * </pre>
  * 


### PR DESCRIPTION
In the current d3js, methods of Zoom allow you not specify a parameter and it would return as specified. An example is scaleExtent where you can specify a range but if you do not specify anything, it would return the current scale. I have added these functions. I also made changes to some of the parameters that I felt would be more ideal.

If someone could review my code, that would be most appreciated.
