### PR TITLE
adjust the imports in the Demo module to cope with transition of Node to HierarchicalLayout.Node

### DIFF
--- a/gwt-d3-demo/src/main/java/com/github/gwtd3/demo/client/democases/TreeDemo.java
+++ b/gwt-d3-demo/src/main/java/com/github/gwtd3/demo/client/democases/TreeDemo.java
@@ -39,7 +39,7 @@ import com.github.gwtd3.api.core.Value;
 import com.github.gwtd3.api.functions.DatumFunction;
 import com.github.gwtd3.api.functions.KeyFunction;
 import com.github.gwtd3.api.layout.Link;
-import com.github.gwtd3.api.layout.Node;
+import com.github.gwtd3.api.layout.HierarchicalLayout.Node;
 import com.github.gwtd3.api.layout.Tree;
 import com.github.gwtd3.api.svg.Diagonal;
 import com.github.gwtd3.demo.client.DemoCase;

--- a/gwt-d3-demo/src/main/java/com/github/gwtd3/demo/client/democases/layout/ClusterDendogram.java
+++ b/gwt-d3-demo/src/main/java/com/github/gwtd3/demo/client/democases/layout/ClusterDendogram.java
@@ -36,7 +36,7 @@ import com.github.gwtd3.api.functions.DatumFunction;
 import com.github.gwtd3.api.functions.PropertyValueFunction;
 import com.github.gwtd3.api.layout.Cluster;
 import com.github.gwtd3.api.layout.Link;
-import com.github.gwtd3.api.layout.Node;
+import com.github.gwtd3.api.layout.HierarchicalLayout.Node;
 import com.github.gwtd3.api.svg.Diagonal;
 import com.github.gwtd3.demo.client.DemoCase;
 import com.github.gwtd3.demo.client.Factory;


### PR DESCRIPTION
This should fix the compilation problems. I deployed the generated jar and TreeDemo and ClusterDendogram looks working. Please verify and accept the pull request if you think everything is in order.