### PR TITLE
expose d3.event.timeStamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ add the gwt-d3-api module to your pom.xml:
   <dependency>
     <groupId>com.github.gwtd3</groupId>
     <artifactId>gwt-d3-api</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <scope>provided</scope>
   </dependency>
   ...
@@ -45,7 +45,7 @@ Note: these JARs don't contain any server-side code, so you don't need to packag
 **Without Maven**
 
 Download [gwt-d3-js-3.5.3.jar](http://central.maven.org/maven2/com/github/gwtd3/gwt-d3-js/3.5.3/gwt-d3-js-3.5.3.jar),
-[gwt-d3-api-1.1.0.jar](http://central.maven.org/maven2/com/github/gwtd3/gwt-d3-api/1.1.0/gwt-d3-api-1.1.0.jar).
+[gwt-d3-api-1.1.1.jar](http://central.maven.org/maven2/com/github/gwtd3/gwt-d3-api/1.1.0/gwt-d3-api-1.1.1.jar).
 Add the JARs to the project classpath.
 
 Note: these JARs don't contain any server-side code, so you don't need to package them into your webapp.
@@ -74,11 +74,13 @@ Launch your application; the current version of d3.js should be displayed.
 - Look at the <a href="http://gwt-d3.appspot.com/">demo</a>.
 
 ##API docs
+* [1.1.1](http://gwtd3.github.io/gwt-d3/apidocs/1.1.1/)
 * [1.1.0](http://gwtd3.github.io/gwt-d3/apidocs/1.1.0/)
 * [1.0.1](http://gwtd3.github.io/gwt-d3/apidocs/1.0.1/)
 * [1.0.0](http://gwtd3.github.io/gwt-d3/apidocs/1.0.0/)
 
 ##Release notes
+- 1.1.1 (6th of feb 2015) : integrated a bug fix (color brighter() and darker() methods take a decimal rather than an integer argument
 - 1.1.0 (3rd of feb 2015) : made GWT 2.7-compliant, completed SVG Shapes,SVG Controls, and Geometry API + some bug fixes
 - 1.0.1 (7th of dec 2013) : a bug fix release to make gwt-d3 compatible with GWT super dev mode.
 - 1.0.0 (30th of sept 2013) : initial release (see below for the API coverage)
@@ -87,7 +89,7 @@ Launch your application; the current version of d3.js should be displayed.
 
 ##Scope and coverage
 
-Currently (3th of dec 2014), version 1.1.0 of gwt-d3 depends on the version 3.5.3 of d3.js codebase.
+Currently (3th of dec 2014), version 1.1.1 of gwt-d3 depends on the version 3.5.3 of d3.js codebase.
 However, not all the API is covered. Please also have a look to the <a href="https://github.com/gwtd3/gwt-d3/issues?milestone=&page=1&state=open">issues</a>.
 
 #####CORE
@@ -185,6 +187,7 @@ However, not all the API is covered. Please also have a look to the <a href="htt
 
 | GWT-D3 version | d3.js version | GWT-D3 release date  |
 | -------------: | -------------:| -----:|
+| [1.1.1](http://central.maven.org/maven2/com/github/gwtd3/gwt-d3-api/1.1.1/)          | 3.5.3        | 2015 02 06  |
 | [1.1.0](http://central.maven.org/maven2/com/github/gwtd3/gwt-d3-api/1.1.0/)          | 3.5.3        | 2015 02 03  |
 | [1.0.1](http://central.maven.org/maven2/com/github/gwtd3/gwt-d3-api/1.0.1/)          | 3.3.10        | 2013 12 07  |
 | [1.0.0](http://central.maven.org/maven2/com/github/gwtd3/gwt-d3-api/1.0.0/)          | 3.3.6         | 2013 09 30  |

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Note: these JARs don't contain any server-side code, so you don't need to packag
 **Without Maven**
 
 Download [gwt-d3-js-3.5.3.jar](http://central.maven.org/maven2/com/github/gwtd3/gwt-d3-js/3.5.3/gwt-d3-js-3.5.3.jar),
-[gwt-d3-api-1.1.1.jar](http://central.maven.org/maven2/com/github/gwtd3/gwt-d3-api/1.1.0/gwt-d3-api-1.1.1.jar).
+[gwt-d3-api-1.1.1.jar](http://central.maven.org/maven2/com/github/gwtd3/gwt-d3-api/1.1.1/gwt-d3-api-1.1.1.jar).
 Add the JARs to the project classpath.
 
 Note: these JARs don't contain any server-side code, so you don't need to package them into your webapp.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Launch your application; the current version of d3.js should be displayed.
 - The best way to learn D3 is to read the <a href="https://github.com/mbostock/d3/wiki/Tutorials">d3.js tutorials</a> 
 - Then you may want to check the examples gallery from <a href="https://github.com/mbostock/d3/wiki/Gallery">Mike Bostock website</a>
 - You may also be interested in forking the gwt-d3 repository to see the demo source code
-- Read the <a href="http://gwtd3.github.io/gwt-d3/apidocs/1.1.0">Javadocs</a>
+- Read the <a href="http://gwtd3.github.io/gwt-d3/apidocs/1.1.1">Javadocs</a>
 - Look at the <a href="http://gwt-d3.appspot.com/">demo</a>.
 
 ##API docs

--- a/gwt-d3-api/src/main/java/com/github/gwtd3/api/D3Event.java
+++ b/gwt-d3-api/src/main/java/com/github/gwtd3/api/D3Event.java
@@ -46,4 +46,15 @@ public class D3Event extends Event {
     public native final <T extends Event> T sourceEvent() /*-{
 		return this.sourceEvent;
     }-*/;
+
+    /**
+     * Returns the timestamp of this instance.
+     * <p>
+     * This
+     *
+     * @return the timestamp of the event
+     */
+    public native final int timeStamp() /*-{
+        return this.timeStamp;
+    }-*/;
 }


### PR DESCRIPTION
It is necessary in order to emulate double tap (click) behavior in touch interfaces. See http://bl.ocks.org/jczaplew/7018691